### PR TITLE
Add portuguese .po file translation

### DIFF
--- a/po/pt.po
+++ b/po/pt.po
@@ -1,0 +1,108 @@
+# Portuguese translations for com.github.artemanufrij.imageburner package.
+# Copyright (C) 2019 THE com.github.artemanufrij.imageburner'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the com.github.artemanufrij.imageburner package.
+# Leandro Vital, 2019.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: com.github.artemanufrij.imageburner\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-08-12 17:52+0200\n"
+"PO-Revision-Date: 2019-09-16 15:24+0100\n"
+"Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
+"Language-Team: Portugese\n"
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.0.6\n"
+
+#: src/MainWindow.vala:67 src/MainWindow.vala:89
+msgid "Change"
+msgstr "Alterar"
+
+#: src/MainWindow.vala:70 src/MainWindow.vala:334
+msgid "Open"
+msgstr "Abrir"
+
+#: src/MainWindow.vala:97 src/MainWindow.vala:255
+msgid "Device"
+msgstr "Dispositivo"
+
+#: src/MainWindow.vala:124
+msgid "Calculating checksum…"
+msgstr "A calcular o checksum…"
+
+#: src/MainWindow.vala:144
+msgid "please wait…"
+msgstr "por favor, espere…"
+
+#: src/MainWindow.vala:156 src/MainWindow.vala:421
+msgid "Ready!"
+msgstr "Pronto!"
+
+#: src/MainWindow.vala:158
+#, c-format
+msgid "%s was written onto %s"
+msgstr "%s foi escrito em %s"
+
+#: src/MainWindow.vala:185
+msgid "Image Burner"
+msgstr "Gravador de imagem"
+
+#: src/MainWindow.vala:193
+msgid "Choose an algorithm"
+msgstr "Escolha um algoritmo"
+
+#: src/MainWindow.vala:210
+msgid "Finished"
+msgstr "Terminado"
+
+#: src/MainWindow.vala:227
+msgid "Image"
+msgstr "Imagem"
+
+#: src/MainWindow.vala:235
+msgid "Select Image"
+msgstr "Selecionar imagem"
+
+#: src/MainWindow.vala:269
+msgid "Select Drive"
+msgstr "Selecionar unidade"
+
+#: src/MainWindow.vala:278 src/MainWindow.vala:411
+msgid "No removable devices found…"
+msgstr "Nenhum dispositivo removível encontrado…"
+
+#: src/MainWindow.vala:307
+msgid "Flash"
+msgstr "Criar"
+
+#: src/MainWindow.vala:317
+msgid "Write Image"
+msgstr "Gravar imagem"
+
+#: src/MainWindow.vala:336
+msgid "_Cancel"
+msgstr "_Cancelar"
+
+#: src/MainWindow.vala:337
+msgid "_Open"
+msgstr "_Abrir"
+
+#: src/MainWindow.vala:340
+msgid "Image files"
+msgstr "Ficheiros de imagem"
+
+#: src/MainWindow.vala:403
+msgid "Choose an image file…"
+msgstr "Escolha um ficheiro de imagem…"
+
+#: src/MainWindow.vala:417
+msgid "No image file chosen…"
+msgstr "Nenhum ficheiro de imagem selecionado…"
+
+#: src/MainWindow.vala:419
+msgid "No device chosen…"
+msgstr "Nenhum dispositivo selecionado…"


### PR DESCRIPTION
Add the Portuguese translation completed.
The Portuguese can use pt or pt_PT because is the same language code. I've made pt because is what is used in elementary OS translations.(wich I translate also)
Ex: https://elementary.io/pt/